### PR TITLE
Add Octav API Skill

### DIFF
--- a/domains/data-and-analytics.md
+++ b/domains/data-and-analytics.md
@@ -421,4 +421,6 @@
 | [prospect-research-compiler](https://github.com/OneWave-AI/claude-skills/tree/main/prospect-research-compiler) | Aggregate prospect intelligence from multiple sources including news, social media, company websi... | OneWave-AI |
 
 
+| [octav-api-skill](https://github.com/Octav-Labs/octav-api-skill) | Claude skill for multi-chain crypto portfolio tracking. Query wallet holdings, DeFi positions, transaction history, and token analytics via natural language across 20+ blockchains. | Octav-Labs |
+
 [← Back to Main README](../README.md)


### PR DESCRIPTION
## Description
Adds [octav-api-skill](https://github.com/Octav-Labs/octav-api-skill) to the Data & Analytics domain.

## What is Octav?
[octav-api-skill](https://github.com/Octav-Labs/octav-api-skill) is a Claude skill for multi-chain crypto portfolio tracking. It enables querying wallet holdings, DeFi positions, transaction history, and token analytics via natural language across 20+ blockchains.

Entry added to `domains/data-and-analytics.md` in the Business Intelligence section.

## Links
- GitHub: https://github.com/Octav-Labs/octav-api-skill
- Skills.sh: https://skills.sh/octav-labs/octav-api-skill/octav-api