### PR TITLE
Add product-manager-skills to Business & Productivity

### DIFF
--- a/domains/business-and-productivity.md
+++ b/domains/business-and-productivity.md
@@ -76,6 +76,7 @@
 | [Photography](https://github.com/moltbot/skills/tree/main/skills/ivangdavila/photography) | Camera settings, composition, lighting, editing workflow, and genre-specific techniques. | moltbot |
 | [pls-marketing-ideas](https://github.com/moltbot/skills/tree/main/skills/mattvalenta/pls-marketing-ideas) |  | moltbot |
 | [postsyncer](https://github.com/moltbot/skills/tree/main/skills/abakermi/openclaw-postsyncer) | Manage your PostSyncer social media workflows. | moltbot |
+| [product-manager-skills](https://github.com/Digidai/product-manager-skills) | Senior PM agent with 6 knowledge domains, 12 templates, and 30+ frameworks for discovery, strategy, delivery, SaaS metrics, PM career coaching, and AI product craft. | Digidai |
 | [pushover-notify](https://github.com/moltbot/skills/tree/main/skills/digitallyborn/pushover-notify) | Send push notifications to your phone via Pushover (pushover.net). Use when you want reliable out... | moltbot |
 | [qinglong-crm-extractor](https://github.com/moltbot/skills/tree/main/skills/pandasun/qinglong-crm-extractor) |  | moltbot |
 | [reef-n8n-automation](https://github.com/moltbot/skills/tree/main/skills/staybased/reef-n8n-automation) |  | moltbot |


### PR DESCRIPTION
## Summary

- Adds [product-manager-skills](https://github.com/Digidai/product-manager-skills) to the Business & Productivity domain
- Senior PM agent skill with 6 knowledge domains, 12 templates, and 30+ frameworks covering discovery, strategy, delivery, SaaS metrics, PM career coaching (IC to CPO), and AI product craft
- Also available on [ClawHub](https://clawhub.ai/Digidai/product-manager-skills): `clawhub install product-manager-skills`

## Details

- **Author:** Digidai
- **GitHub:** https://github.com/Digidai/product-manager-skills
- **Category:** Business & Productivity / Product Management