### PR TITLE
Add Agent Cards skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,4 @@ This repository is licensed under the Apache License 2.0 - see the [LICENSE](LIC
 ---
 
 *Built with ❤️ by the Claude Code community. Empowering developers with AI-enhanced workflows.*
+- [agent-cards/skill](https://github.com/agent-cards/skill) - Manage prepaid virtual Visa cards for AI agents. Create cards, check balances, view credentials, close cards, and get support via MCP tools.


### PR DESCRIPTION
## Summary

Adds [agent-cards/skill](https://github.com/agent-cards/skill) to the list.

**Agent Cards** lets AI agents create and spend prepaid virtual Visa cards — each with a fixed budget, real card credentials, and full MCP integration. The skill teaches agents how to:

- **Create cards** — set a dollar amount, complete Stripe Checkout, get a card back
- **Check balances** — quick balance lookup
- **View card credentials** — full card number, CVV, expiry (with email approval)
- **Close cards** — permanent closure with user confirmation
- **Get support** — open and manage support conversations

Works with Claude Code, Codex, and any agent that supports SKILL.md.

- **Repo:** https://github.com/agent-cards/skill
- **Product:** https://agentcard.sh
- **Install:** `npx skills add agent-cards/skill`