### PR TITLE
chore: add missing type hints in readme_generator.py and skill_scraper.py

### DIFF
--- a/scripts/generators/readme_generator.py
+++ b/scripts/generators/readme_generator.py
@@ -19,11 +19,11 @@ class SkillReadmeGenerator:
         self.marketplaces: List[Dict[str, Any]] = []  # Now contains repositories
         self.skills: List[Dict[str, Any]] = []
 
-    def add_marketplaces(self, marketplaces: List[Dict[str, Any]]):
+    def add_marketplaces(self, marketplaces: List[Dict[str, Any]]) -> None:
         """Add marketplace data."""
         self.marketplaces.extend(marketplaces)
 
-    def add_skills(self, skills: List[Dict[str, Any]]):
+    def add_skills(self, skills: List[Dict[str, Any]]) -> None:
         """Add skill data."""
         self.skills.extend(skills)
 

--- a/scripts/skill_scraper.py
+++ b/scripts/skill_scraper.py
@@ -28,7 +28,7 @@ def setup_logging(level: str = "INFO") -> None:
         format='%(asctime)s - %(levelname)s - %(message)s'
     )
 
-def generate_readme(marketplaces: list, skills: list, output_file: str, args=None) -> bool:
+def generate_readme(marketplaces: list, skills: list, output_file: str, args: list=None) -> bool:
     """Generate README from marketplace and skill data."""
     generator = SkillReadmeGenerator()
     # Handle both dict and object formats
@@ -129,7 +129,7 @@ def parse_marketplace_data(raw_data: dict) -> list:
             marketplaces.append(marketplace)
     return marketplaces
 
-def cmd_generate_readme(args, config, logger):
+def cmd_generate_readme(args: list, config: dict, logger) -> int:
     """Handle generate-readme command."""
     logger.info("Skill Scraper starting...")
 
@@ -200,7 +200,7 @@ def cmd_generate_readme(args, config, logger):
         print("Failed to generate README")
         return 1
 
-def cmd_validate_config(args, config, logger):
+def cmd_validate_config(args: list, config: dict, logger) -> int:
     """Handle validate-config command."""
     print("Configuration validation:")
 
@@ -229,7 +229,7 @@ def cmd_validate_config(args, config, logger):
         print(f"✗ Configuration validation failed: {e}")
         return 1
 
-def cmd_list_sources(args, config, logger):
+def cmd_list_sources(args: list, config: dict, logger) -> int:
     """Handle list-sources command."""
     try:
         sources = config.get_enabled_sources()
@@ -256,7 +256,7 @@ def cmd_list_sources(args, config, logger):
         print(f"Failed to list sources: {e}")
         return 1
 
-def main():
+def main() -> int:
     """Main entry point for the skill scraper."""
     parser = argparse.ArgumentParser(
         description="Generate curated README from Claude marketplace skill data"


### PR DESCRIPTION
Hello,

I noticed a few areas where the code could be made a bit more robust and readable. This PR focuses on minor housekeeping tasks and does not change any of the existing runtime logic:

### Type hint additions
- `readme_generator.py`: added type hints to 2 function(s)
- `skill_scraper.py`: added type hints to 5 function(s)

I have added basic type annotations based on variable names and default values. This should make the code easier to work with in modern IDEs without changing any of the actual logic.

### Examples of changes
**Example change in `readme_generator.py`:**
```diff
-    def add_marketplaces(self, marketplaces: List[Dict[str, Any]]):
+    def add_marketplaces(self, marketplaces: List[Dict[str, Any]]) -> None:
-    def add_skills(self, skills: List[Dict[str, Any]]):
+    def add_skills(self, skills: List[Dict[str, Any]]) -> None:
```

**Example change in `skill_scraper.py`:**
```diff
-def generate_readme(marketplaces: list, skills: list, output_file: str, args=None) -> bool:
+def generate_readme(marketplaces: list, skills: list, output_file: str, args: list=None) -> bool:
-def cmd_generate_readme(args, config, logger):
+def cmd_generate_readme(args: list, config: dict, logger) -> int:
-def cmd_validate_config(args, config, logger):
+def cmd_validate_config(args: list, config: dict, logger) -> int:
-def cmd_list_sources(args, config, logger):
+def cmd_list_sources(args: list, config: dict, logger) -> int:
-def main():
+def main() -> int:
```

---

### Safety and verification
- I verified these changes using `ast.parse()` to ensure no syntax errors were introduced.
- Files using dynamic patterns like `eval()` or `globals()` were automatically skipped.
- I did not modify any `__init__.py` files.

Let me know if you would like me to change anything here.