### PR TITLE
chore: add safe type hints for constants and returns in scripts/generators/readme_generator.py and scripts/skill_scraper.py

### DIFF
--- a/scripts/generators/readme_generator.py
+++ b/scripts/generators/readme_generator.py
@@ -19,11 +19,11 @@ class SkillReadmeGenerator:
         self.marketplaces: List[Dict[str, Any]] = []  # Now contains repositories
         self.skills: List[Dict[str, Any]] = []
 
-    def add_marketplaces(self, marketplaces: List[Dict[str, Any]]):
+    def add_marketplaces(self, marketplaces: List[Dict[str, Any]]) -> None:
         """Add marketplace data."""
         self.marketplaces.extend(marketplaces)
 
-    def add_skills(self, skills: List[Dict[str, Any]]):
+    def add_skills(self, skills: List[Dict[str, Any]]) -> None:
         """Add skill data."""
         self.skills.extend(skills)
 

--- a/scripts/skill_scraper.py
+++ b/scripts/skill_scraper.py
@@ -129,7 +129,7 @@ def parse_marketplace_data(raw_data: dict) -> list:
             marketplaces.append(marketplace)
     return marketplaces
 
-def cmd_generate_readme(args, config, logger):
+def cmd_generate_readme(args, config, logger) -> int:
     """Handle generate-readme command."""
     logger.info("Skill Scraper starting...")
 
@@ -200,7 +200,7 @@ def cmd_generate_readme(args, config, logger):
         print("Failed to generate README")
         return 1
 
-def cmd_validate_config(args, config, logger):
+def cmd_validate_config(args, config, logger) -> int:
     """Handle validate-config command."""
     print("Configuration validation:")
 
@@ -229,7 +229,7 @@ def cmd_validate_config(args, config, logger):
         print(f"✗ Configuration validation failed: {e}")
         return 1
 
-def cmd_list_sources(args, config, logger):
+def cmd_list_sources(args, config, logger) -> int:
     """Handle list-sources command."""
     try:
         sources = config.get_enabled_sources()


### PR DESCRIPTION
Hello,

I noticed a few areas where the code could be slightly improved. This PR focuses on minor housekeeping tasks and does not change any of the existing runtime logic:

### Type hint additions
- `scripts/generators/readme_generator.py`: added type hints to 2 function(s)
- `scripts/skill_scraper.py`: added type hints to 3 function(s)

I have added **strictly conservative** type annotations based only on explicit primitive default values and singular return statements. Complex objects and dynamic references were purposefully ignored to avoid false positives.

### Examples of changes
**Example change in `scripts/generators/readme_generator.py`:**
```diff
-    def add_marketplaces(self, marketplaces: List[Dict[str, Any]]):
+    def add_marketplaces(self, marketplaces: List[Dict[str, Any]]) -> None:
-    def add_skills(self, skills: List[Dict[str, Any]]):
+    def add_skills(self, skills: List[Dict[str, Any]]) -> None:
```
**Example change in `scripts/skill_scraper.py`:**
```diff
-def cmd_generate_readme(args, config, logger):
+def cmd_generate_readme(args, config, logger) -> int:
-def cmd_validate_config(args, config, logger):
+def cmd_validate_config(args, config, logger) -> int:
-def cmd_list_sources(args, config, logger):
+def cmd_list_sources(args, config, logger) -> int:
```

---
### Verification
- I verified these changes using `ast.parse()` to ensure no syntax errors were introduced.
- I did not modify any `__init__.py` files.

If anything looks incorrect, please feel free to adjust it or close the PR entirely. Thank you for maintaining this project!