### PR TITLE
Add yield-intelligence, moatmri, and doc2math — finance/strategy/formalization skills

### DIFF
--- a/domains/business-and-productivity.md
+++ b/domains/business-and-productivity.md
@@ -1,7 +1,5 @@
 # Business & Productivity
 
-| [yield-intelligence](https://github.com/thebrierfox/yield-intelligence-skill) | Passive income portfolio analysis across US Treasuries, dividend ETFs, REITs, and preferred stocks. Build allocations targeting a specific monthly income goal — conservative, moderate, or aggressive. | thebrierfox |
-| [moatmri](https://github.com/thebrierfox/moatmri-skill) | AI disruption pressure analysis — measures moat erosion risk across revenue model, workflow defensibility, and talent leverage. Returns a ranked threat map and strategic countermove set. | thebrierfox |
 [← Back to Main README](../README.md)
 
 *98 skills in this domain*

--- a/domains/business-and-productivity.md
+++ b/domains/business-and-productivity.md
@@ -1,5 +1,7 @@
 # Business & Productivity
 
+| [yield-intelligence](https://github.com/thebrierfox/yield-intelligence-skill) | Passive income portfolio analysis across US Treasuries, dividend ETFs, REITs, and preferred stocks. Build allocations targeting a specific monthly income goal — conservative, moderate, or aggressive. | thebrierfox |
+| [moatmri](https://github.com/thebrierfox/moatmri-skill) | AI disruption pressure analysis — measures moat erosion risk across revenue model, workflow defensibility, and talent leverage. Returns a ranked threat map and strategic countermove set. | thebrierfox |
 [← Back to Main README](../README.md)
 
 *98 skills in this domain*
@@ -111,4 +113,6 @@
 | [Zoho Books Automation](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/composio-skills/zoho-books-automation) | Automate Zoho Books accounting workflows including invoice creation, bill management, contact loo... | ComposioHQ |
 
 
+| [yield-intelligence](https://github.com/thebrierfox/yield-intelligence-skill) | Passive income portfolio analysis across US Treasuries, dividend ETFs, REITs, and preferred stocks. Build allocations targeting a specific monthly income goal — conservative, moderate, or aggressive. | thebrierfox |
+| [moatmri](https://github.com/thebrierfox/moatmri-skill) | AI disruption pressure analysis — measures moat erosion risk across revenue model, workflow defensibility, and talent leverage. Returns a ranked threat map and strategic countermove set. | thebrierfox |
 [← Back to Main README](../README.md)

--- a/domains/data-and-analytics.md
+++ b/domains/data-and-analytics.md
@@ -1,5 +1,6 @@
 # Data & Analytics
 
+| [doc2math](https://github.com/thebrierfox/doc2math-skill) | Document-to-mathematics formalization — converts natural language problem statements, specs, or documents into rigorous mathematical notation. Supports proof sketches, formal definitions, and symbolic representation extraction. | thebrierfox |
 [← Back to Main README](../README.md)
 
 *793 skills in this domain*
@@ -854,4 +855,5 @@
 | [forecasting-time-series-data](https://github.com/jeremylongshore/claude-code-plugins-plus-skills/tree/main/plugins/ai-ml/time-series-forecaster/skills/forecasting-time-series-data) | Process this skill enables AI assistant to forecast future values based on historical time series... | jeremylongshore |
 
 
+| [doc2math](https://github.com/thebrierfox/doc2math-skill) | Document-to-mathematics formalization — converts natural language problem statements, specs, or documents into rigorous mathematical notation. Supports proof sketches, formal definitions, and symbolic representation extraction. | thebrierfox |
 [← Back to Main README](../README.md)

--- a/domains/data-and-analytics.md
+++ b/domains/data-and-analytics.md
@@ -1,6 +1,5 @@
 # Data & Analytics
 
-| [doc2math](https://github.com/thebrierfox/doc2math-skill) | Document-to-mathematics formalization — converts natural language problem statements, specs, or documents into rigorous mathematical notation. Supports proof sketches, formal definitions, and symbolic representation extraction. | thebrierfox |
 [← Back to Main README](../README.md)
 
 *793 skills in this domain*


### PR DESCRIPTION
Three Claude skills from IntuiTek¹ / thebrierfox:

## Skills Added

**Business & Productivity domain:**
- **[yield-intelligence](https://github.com/thebrierfox/yield-intelligence-skill)** — Passive income portfolio analysis across US Treasuries, dividend ETFs, REITs, and preferred stocks. Build allocations targeting a specific monthly income goal.
- **[moatmri](https://github.com/thebrierfox/moatmri-skill)** — AI disruption pressure analysis — measures moat erosion risk across revenue model, workflow defensibility, and talent leverage. Returns a ranked threat map and strategic countermove set.

**Data & Analytics domain:**
- **[doc2math](https://github.com/thebrierfox/doc2math-skill)** — Document-to-mathematics formalization — converts natural language problem statements into rigorous mathematical notation. Supports proof sketches, formal definitions, and symbolic representation extraction.

All three are standalone, open-source Claude Code skills hosted at github.com/thebrierfox.