### PR TITLE
Add AccInt Solve skill

### DIFF
--- a/domains/ai-and-llm.md
+++ b/domains/ai-and-llm.md
@@ -783,6 +783,7 @@
 | [zoho-mail-automation](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/composio-skills/zoho-mail-automation) | Automate Zoho Mail tasks via Rube MCP (Composio). Always search tools first for current schemas. | ComposioHQ |
 | [zoho_desk-automation](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/composio-skills/zoho_desk-automation) | Automate Zoho Desk tasks via Rube MCP (Composio): tickets, contacts, agents, departments, and hel... | ComposioHQ |
 | [zoho_mail-automation](https://github.com/ComposioHQ/awesome-claude-skills/tree/master/composio-skills/zoho_mail-automation) | Automate Zoho Mail tasks via Rube MCP (Composio): email sending, folders, labels, and mailbox man... | ComposioHQ |
+| [AccInt Solve](https://github.com/maxbaluev/accreted-intelligence/tree/main/plugins/claude/skills/solve) | Routes coding agents through AccInt MCP memory: retrieve outcomes, solve commitments, frames, and feedback. | maxbaluev |
 
 
 [← Back to Main README](../README.md)


### PR DESCRIPTION
## What changed

Adds AccInt Solve to the AI & LLM domain file.

## Why

AccInt Solve is a public Claude/Codex-compatible skill for using AccInt's MCP-backed memory loop during coding-agent work: retrieve prior outcomes, open solve commitments, resolve continuation frames, and record verified feedback.

The AI & LLM domain already includes agent-memory and MCP-backed AI-agent workflow skills, so this is the closest section fit.

## Validation

- `git diff --check`
- AccInt Solve link returns HTTP 200
- Local table-row shape check for `domains/ai-and-llm.md`
