### PR TITLE
config: point source 2 to Chat2AnyLLM/code-agent-manager

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,9 +8,9 @@ sources:
     priority: 1
     timeout: 30
 
-  - id: "claude-skill-repos"  # Using your fork that has the missing jeremylongshore/claude-code-plugins-plus-skills repo
+  - id: "claude-skill-repos"
     # Repo renamed: code-assistant-manager -> code-agent-manager (inner dir name kept the old "code_assistant_manager")
-    url: "https://raw.githubusercontent.com/zhujian0805/code-agent-manager/main/code_assistant_manager/skill_repos.json"
+    url: "https://raw.githubusercontent.com/Chat2AnyLLM/code-agent-manager/main/code_assistant_manager/skill_repos.json"
     format: "json"
     enabled: true
     priority: 2


### PR DESCRIPTION
## Summary
Source 2 in `config.yaml` previously pointed at `zhujian0805/code-agent-manager`. Switching to the org-owned fork `Chat2AnyLLM/code-agent-manager` so both data sources live under the same org.

## Context
- Source 1: `Chat2AnyLLM/awesome-repo-configs` (73 repos)
- Source 2 (this change): `Chat2AnyLLM/code-agent-manager` — same path inside the repo (`code_assistant_manager/skill_repos.json`)

## Note on skill count
Today `Total Skills: 2974`. The historical figure (~10,300) was driven by 6 large repos that no longer appear in either source:
- jeremylongshore/claude-code-plugins-plus-skills (~3,600 skills)
- wshobson/agents (~156)
- anthropics/skills (~18)
- diet103/claude-code-infrastructure-showcase (~5)
- obra/superpowers (~14)
- jeremylongshore/claude-code-plugins-plus (now a GitHub rename redirect)

A follow-up PR against `Chat2AnyLLM/code-agent-manager` will re-add those repos to its `skill_repos.json`, which will bring the count back into the ~6,800 range after the next hourly cron run.