### PR TITLE
Add awesome-claude-code-hooks to related lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Metadata catalog for Claude Code skill source repositories. This repo does **not
 - Healthy repos: **4439** · Truncated: **2** · Unavailable: **153**
 - Last updated: **2026-09-03 06:36 UTC**
 
+## Related Lists
+
+- [loqimean/awesome-claude-code-hooks](https://github.com/loqimean/awesome-claude-code-hooks) - Curated list of Claude Code hooks for extending and automating Claude Code workflows.
+
 ## Source Catalog
 
 | Repository | Skills | Branch | Path | Status | Note |

--- a/scripts/metadata_catalog.py
+++ b/scripts/metadata_catalog.py
@@ -7,6 +7,13 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 UA = "awesome-metadata-catalog/1.0"
+RELATED_LISTS = [
+    (
+        "loqimean/awesome-claude-code-hooks",
+        "https://github.com/loqimean/awesome-claude-code-hooks",
+        "Curated list of Claude Code hooks for extending and automating Claude Code workflows.",
+    ),
+]
 
 
 def _jget(url: str, token: str | None) -> dict:
@@ -98,6 +105,10 @@ def render_readme(entries: list[dict], counts: dict[str, dict]) -> str:
         f"- Discoverable skills: **{total:,}**",
         f"- Healthy repos: **{ok}** · Truncated: **{trunc}** · Unavailable: **{bad}**",
         f"- Last updated: **{ts}**",
+        "",
+        "## Related Lists",
+        "",
+        *[f"- [{name}]({url}) - {description}" for name, url, description in RELATED_LISTS],
         "",
         "## Source Catalog",
         "",


### PR DESCRIPTION
Adding a link to https://github.com/loqimean/awesome-claude-code-hooks, a curated list of Claude Code hooks. It's a related resource for people using this catalog to find Claude Code tooling, so I added it under a small new 'Related Lists' section above the main source catalog table.

Didn't touch the auto-generated Source Catalog table itself since that's maintained by the scraper workflow.