### PR TITLE
Fix generated README reminder workflow

### DIFF
--- a/.github/workflows/remind-readme-contributions.yml
+++ b/.github/workflows/remind-readme-contributions.yml
@@ -20,8 +20,6 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const core = require('@actions/core');
-
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const pullNumber = context.payload.pull_request.number;


### PR DESCRIPTION
`actions/github-script` already injects `core`. Remove the duplicate declaration that causes every README reminder run to fail with `SyntaxError`.