### PR TITLE
Add Continuum-AI-Corp/OrcaReplay to the Source Catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,6 +880,7 @@ Metadata catalog for Claude Code skill source repositories. This repo does **not
 | [connerkward/macos-screen-recorder-system-audio](https://github.com/connerkward/macos-screen-recorder-system-audio) | 0 | `main` | `.` | ✅ ok |  |
 | [conorbronsdon/agent-skill-builder](https://github.com/conorbronsdon/agent-skill-builder) | 4 | `main` | `.` | ✅ ok |  |
 | [conorbronsdon/agent-workspace](https://github.com/conorbronsdon/agent-workspace) | 6 | `main` | `skills` | ✅ ok |  |
+| [Continuum-AI-Corp/OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) | 1 | `main` | `skills` | ✅ ok |  |
 | [ContextJet-ai/awesome-llm-observability](https://github.com/ContextJet-ai/awesome-llm-observability) | 26 | `main` | `skills` | ✅ ok |  |
 | [controlplane-com/ai-plugin](https://github.com/controlplane-com/ai-plugin) | 30 | `main` | `.` | ✅ ok |  |
 | [convergeai-labs/enter-skills](https://github.com/convergeai-labs/enter-skills) | 1 | `main` | `skills` | ✅ ok |  |


### PR DESCRIPTION
Adds [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) — one line, in the section this fits.

**Disclosure: I work on it.** Apache-2.0, free, no paid tier, no account.

## What it is

A record/replay debugger for coding agents. It captures a run **below the harness** — a base-URL variable moved for that process, or TLS terminated for one named host — so the agent itself is unmodified and needs no SDK, exporter or plugin. The trace keeps the verbatim request and response bytes, which is what makes the next part possible: the run re-executes with the network off (`egress=blocked`), served the recorded exchanges back.

```bash
npm i -g orcareplay
orca record claude            # or codex, goose, hermes, opencode, qwen, cursor, grok, openclaw
orca replay last              # reproduce it, network off
orca compare last --models a,b,c --verify "npm test"
```

## Why it is not the same thing as the tracing tools already listed

The OpenTelemetry path — which is what Langfuse, Phoenix and the rest consume — does not capture message content by default, and even with `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true` what lands is span attributes: a normalised *view* of the call, not the bytes on the wire. You cannot serve a span back to an SDK as an HTTP response. It also assumes the agent can be instrumented, and the agents most people actually run — Claude Code, Codex CLI, goose — are binaries you invoke, not libraries you import.

So this sits beside those tools rather than replacing them: they are the system of record for a fleet, this is a debugger you point at one run.

## Verified, not asserted

Two harnesses have been driven end to end against the real thing, and each broke something that got fixed:

- **Claude Code** — [walked through against a real bug fix](https://github.com/Continuum-AI-Corp/OrcaReplay/blob/main/docs/validation.md).
- **goose** 1.49.0 — `1 failed` → agent fixes it → `1 passed`, then strict offline replay `reused=8/8 exact=8 divergences=0`, three runs in a row.
- **Hermes** v0.21.0 — recorded and replayed offline, `reused=1/1 egress=blocked`.

Every adapter has a fixture recording the exact environment variables it sets, so a harness that renames one turns a check red instead of producing an empty trace.

## Details

- Apache-2.0 · TypeScript · Linux/macOS/Windows · `npm i -g orcareplay`
- Ships an MCP server (`orca mcp`, protocol `2025-06-18`) and an Agent Skill
- Listed in the official MCP Registry
- ~1,700 tests and a trace-format conformance suite

Happy to reword, shorten, or move it to a different section — say which and I will push the change.
