### PR TITLE
Keep the catalog honest when the GitHub hourly quota runs out

### DIFF
--- a/scripts/metadata_catalog.py
+++ b/scripts/metadata_catalog.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-import json, os
+import json, os, re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
+from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 UA = "awesome-metadata-catalog/1.0"
+# Statuses that came from an answered request. Anything else is an unknown the
+# next run should spend its quota on first.
+MEASURED = {"ok", "truncated", "missing"}
+CARRY_NOTE = "not rechecked this run, GitHub hourly quota spent"
 RELATED_LISTS = [
     (
         "loqimean/awesome-claude-code-hooks",
@@ -16,12 +21,41 @@ RELATED_LISTS = [
 ]
 
 
-def _jget(url: str, token: str | None) -> dict:
+class Budget:
+    """One run's share of the GitHub hourly quota.
+
+    The catalog needs one tree request per source repository, and the list is
+    already larger than an hour's allowance. Once the allowance is spent every
+    further request comes back 403, so the run stops asking instead of turning
+    the rest of the catalog into error rows.
+    """
+
+    def __init__(self) -> None:
+        self.spent = False
+        self.reset_at = ""
+
+    def note_403(self, headers) -> bool:
+        """True when this 403 is the quota running out, not a private repo."""
+        if headers.get("X-RateLimit-Remaining") == "0" or headers.get("Retry-After"):
+            self.spent = True
+            reset = headers.get("X-RateLimit-Reset")
+            if reset and reset.isdigit():
+                self.reset_at = datetime.fromtimestamp(int(reset), timezone.utc).strftime("%H:%M UTC")
+            return True
+        return False
+
+
+def _jget(url: str, token: str | None, budget: "Budget | None" = None) -> dict:
     headers = {"User-Agent": UA, "Accept": "application/vnd.github+json"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    with urlopen(Request(url, headers=headers), timeout=30) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+    try:
+        with urlopen(Request(url, headers=headers), timeout=30) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except HTTPError as e:
+        if e.code == 403 and budget is not None:
+            budget.note_403(e.headers)
+        raise
 
 
 def fetch_repos_from_sources(sources: list[dict]) -> list[dict]:
@@ -47,12 +81,35 @@ def _fields(entry: dict) -> dict:
     }
 
 
-def _count_skill(entry: dict, token: str | None) -> dict:
+def _carry_over(full: str, f: dict, previous: dict, budget: "Budget") -> dict:
+    """What to publish for a repository this run could not reach.
+
+    A stale number that was measured is worth more than a fresh zero that was
+    not, so the previous row is reused verbatim when there is one.
+    """
+    kept = previous.get(full)
+    when = f" (quota resets {budget.reset_at})" if budget.reset_at else ""
+    if kept and kept.get("status") in MEASURED:
+        # Strip the marker a previous carry-over may have left, so the note
+        # does not grow by one clause per skipped run.
+        note = (kept.get("note") or "").split(CARRY_NOTE)[0].strip().rstrip(";").strip()
+        note = f"{note}; " if note else ""
+        return {**kept, "full": full, "branch": f["branch"], "path": f["path"],
+                "note": f"{note}{CARRY_NOTE}{when}", "_carried": True}
+    return {"full": full, "count": 0, "status": "pending", "branch": f["branch"], "path": f["path"],
+            "note": f"not counted yet, GitHub hourly quota spent{when}", "_carried": True}
+
+
+def _count_skill(entry: dict, token: str | None, budget: "Budget", previous: dict) -> dict:
     f = _fields(entry)
     full = f"{f['owner']}/{f['name']}"
+    if budget.spent:
+        return _carry_over(full, f, previous, budget)
     try:
-        tree = _jget(f"https://api.github.com/repos/{full}/git/trees/{f['branch']}?recursive=1", token)
+        tree = _jget(f"https://api.github.com/repos/{full}/git/trees/{f['branch']}?recursive=1", token, budget)
     except HTTPError as e:
+        if e.code == 403 and budget.spent:
+            return _carry_over(full, f, previous, budget)
         status = "missing" if e.code == 404 else "forbidden" if e.code == 403 else "error"
         return {"full": full, "count": 0, "status": status, "note": f"HTTP {e.code}", "branch": f["branch"], "path": f["path"]}
     except (URLError, OSError, TimeoutError) as e:
@@ -71,18 +128,93 @@ def _count_skill(entry: dict, token: str | None) -> dict:
     return {"full": full, "count": count, "status": "truncated" if trunc else "ok", "note": "tree truncated; count is lower bound" if trunc else "", "branch": f["branch"], "path": f["path"]}
 
 
-def count_skills(entries: list[dict], max_workers: int = 8) -> dict[str, dict]:
+def _scan_order(entries: list[dict], previous: dict, offset: int) -> tuple[list[dict], int]:
+    """Repositories nobody has counted yet go first, the rest rotate.
+
+    Source configs grow by appending, so a fixed order spends the whole quota
+    on the same head of the list and every newly added repository starves: on
+    12 Sep 2026 all 392 unreachable rows sat at index 4780 and beyond, out of
+    5174.
+    """
+    fresh, known = [], []
+    for e in entries:
+        f = _fields(e)
+        row = previous.get(f"{f['owner']}/{f['name']}")
+        (known if row and row.get("status") in MEASURED else fresh).append(e)
+    if known:
+        start = offset % len(known)
+        known = known[start:] + known[:start]
+    return fresh + known, len(fresh)
+
+
+def count_skills(entries: list[dict], max_workers: int = 8, previous: dict | None = None,
+                 offset: int = 0) -> tuple[dict[str, dict], int]:
+    """Count skills for as many repositories as the hourly quota allows.
+
+    Returns the counts and the cursor the next run should start from. The
+    cursor stays 0 while one run still covers the whole catalog.
+    """
     token = os.environ.get("GITHUB_TOKEN")
-    out = {}
+    previous = previous or {}
+    budget = Budget()
+    ordered, fresh_count = _scan_order(entries, previous, offset)
+    out, carried = {}, set()
     with ThreadPoolExecutor(max_workers=max_workers) as ex:
-        futs = {ex.submit(_count_skill, e, token): e for e in entries}
+        futs = {ex.submit(_count_skill, e, token, budget, previous): e for e in ordered}
         for fut in as_completed(futs):
             r = fut.result()
+            if r.pop("_carried", False):
+                carried.add(r["full"])
             out[r["full"]] = r
-    return out
+    if not carried:
+        return out, 0
+    known_done = 0
+    for e in ordered[fresh_count:]:
+        f = _fields(e)
+        if f"{f['owner']}/{f['name']}" not in carried:
+            known_done += 1
+    return out, offset + known_done
 
 
-def render_readme(entries: list[dict], counts: dict[str, dict]) -> str:
+OFFSET_MARK = "<!-- scan-offset: "
+_ROW = re.compile(r"^\| \[([^\]]+)\]\([^)]*\) \| (\u2265?[\d,]+) \| `([^`]*)` \| `([^`]*)` \| \S+ (\w+) \|(.*)\|\s*$")
+_STATUS_WORD = {"ok": "ok", "truncated": "truncated", "missing": "missing", "forbidden": "forbidden", "error": "error", "pending": "pending"}
+
+
+def read_previous(output_file: str) -> tuple[dict, int]:
+    """Recover the last run's table so a spent quota cannot erase it."""
+    path = Path(output_file)
+    if not path.exists():
+        return {}, 0
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}, 0
+    offset = 0
+    for line in text.split("\n"):
+        if line.startswith(OFFSET_MARK):
+            digits = line[len(OFFSET_MARK):].split("-")[0].strip()
+            offset = int(digits) if digits.isdigit() else 0
+            break
+    rows = {}
+    for line in text.split("\n"):
+        m = _ROW.match(line)
+        if not m:
+            continue
+        full, count, branch, path_, status, note = m.groups()
+        status = _STATUS_WORD.get(status, status)
+        rows[full] = {
+            "full": full,
+            "count": int(count.lstrip("\u2265").replace(",", "")),
+            "status": status,
+            "branch": branch,
+            "path": "" if path_ == "." else path_,
+            "note": note.strip().replace("\\|", "|"),
+        }
+    return rows, offset
+
+
+def render_readme(entries: list[dict], counts: dict[str, dict], next_offset: int = 0) -> str:
     rows = []
     for e in entries:
         f = _fields(e)
@@ -106,6 +238,8 @@ def render_readme(entries: list[dict], counts: dict[str, dict]) -> str:
         f"- Healthy repos: **{ok}** · Truncated: **{trunc}** · Unavailable: **{bad}**",
         f"- Last updated: **{ts}**",
         "",
+        f"{OFFSET_MARK}{next_offset} -->",
+        "",
         "## Related Lists",
         "",
         *[f"- [{name}]({url}) - {description}" for name, url, description in RELATED_LISTS],
@@ -119,7 +253,7 @@ def render_readme(entries: list[dict], counts: dict[str, dict]) -> str:
         repo = f"[{r['full']}](https://github.com/{r['full']})"
         count = f"≥{r['count']:,}" if r['status'] == 'truncated' else f"{r['count']:,}"
         path = f"`{r['path'] or '.'}`"
-        status = {"ok": "✅ ok", "truncated": "⚠️ truncated", "missing": "❌ missing", "forbidden": "⛔ forbidden", "error": "❌ error"}.get(r['status'], r['status'])
+        status = {"ok": "✅ ok", "truncated": "⚠️ truncated", "missing": "❌ missing", "forbidden": "⛔ forbidden", "error": "❌ error", "pending": "⏳ pending"}.get(r['status'], r['status'])
         note = (r.get("note") or "").replace("|", "\\|")
         lines.append(f"| {repo} | {count} | `{r['branch']}` | {path} | {status} | {note} |")
     lines += ["", "## Contributing", "", "Add or disable source repositories in [awesome-repo-configs](https://github.com/Chat2AnyLLM/awesome-repo-configs). This repository is a metadata-only catalog."]

--- a/scripts/skill_scraper.py
+++ b/scripts/skill_scraper.py
@@ -12,10 +12,10 @@ from pathlib import Path
 
 try:
     from .config import Config
-    from .metadata_catalog import fetch_repos_from_sources, count_skills, render_readme
+    from .metadata_catalog import fetch_repos_from_sources, count_skills, read_previous, render_readme
 except ImportError:
     from config import Config
-    from metadata_catalog import fetch_repos_from_sources, count_skills, render_readme
+    from metadata_catalog import fetch_repos_from_sources, count_skills, read_previous, render_readme
 
 def setup_logging(level: str = "INFO") -> None:
     """Setup logging configuration."""
@@ -25,9 +25,9 @@ def setup_logging(level: str = "INFO") -> None:
         format='%(asctime)s - %(levelname)s - %(message)s'
     )
 
-def generate_readme(repositories: list, counts: dict, output_file: str, args: list = None) -> bool:
+def generate_readme(repositories: list, counts: dict, output_file: str, args: list = None, next_offset: int = 0) -> bool:
     """Generate README from source-repository metadata + GitHub API counts."""
-    content = render_readme(repositories, counts)
+    content = render_readme(repositories, counts, next_offset)
 
     output_path = Path(output_file)
     if output_path.exists() and not getattr(args, 'force', False):
@@ -81,17 +81,22 @@ def cmd_generate_readme(args: list, config: dict, logger) -> int:
     repositories = fetch_repos_from_sources(sources)
     logger.info("Loaded %d enabled repositories from source configs", len(repositories))
 
-    counts = count_skills(repositories, max_workers=config.get_max_workers())
+    previous, offset = read_previous(args.output)
+    counts, next_offset = count_skills(repositories, max_workers=config.get_max_workers(),
+                                       previous=previous, offset=offset)
     total_skills = sum(v.get('count', 0) for v in counts.values())
     unavailable = sum(1 for v in counts.values() if v.get('status') not in {'ok', 'truncated'})
     truncated = sum(1 for v in counts.values() if v.get('status') == 'truncated')
+    pending = sum(1 for v in counts.values() if v.get('status') == 'pending')
     logger.info("Counted %d skills across %d repos (%d unavailable, %d truncated)", total_skills, len(repositories), unavailable, truncated)
+    if next_offset:
+        logger.info("GitHub hourly quota spent; %d repos still uncounted, next run resumes at cursor %d", pending, next_offset)
 
     if hasattr(args, 'dry_run') and args.dry_run:
         print(f"Dry run: Would generate README with {len(repositories)} repositories and {total_skills} discoverable skills")
         return 0
 
-    if generate_readme(repositories, counts, args.output, args):
+    if generate_readme(repositories, counts, args.output, args, next_offset):
         print(f"Successfully generated README with {len(repositories)} repositories and {total_skills} discoverable skills!")
         return 0
     else:

--- a/scripts/test_metadata_catalog.py
+++ b/scripts/test_metadata_catalog.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Offline checks for the quota-aware catalog scan.
+
+Run with `python3 scripts/test_metadata_catalog.py`. No network, no pytest.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+from urllib.error import HTTPError
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import metadata_catalog as mc
+
+
+def _entries(n):
+    return [{"owner": "acme", "name": f"repo{i:04d}", "branch": "main", "skillsPath": "skills"} for i in range(n)]
+
+
+def _fake_github(fail_after):
+    """A GitHub that answers `fail_after` tree requests and then runs out of quota."""
+    state = {"calls": 0}
+
+    def jget(url, token, budget=None):
+        state["calls"] += 1
+        if state["calls"] > fail_after:
+            headers = {"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "1789000000"}
+            error = HTTPError(url, 403, "rate limit exceeded", headers, None)
+            if budget is not None:
+                budget.note_403(headers)
+            raise error
+        return {"tree": [{"type": "blob", "path": "skills/one/SKILL.md"}], "truncated": False}
+
+    return jget, state
+
+
+def test_spent_quota_never_erases_a_measured_count():
+    real, mc._jget = mc._jget, _fake_github(10)[0]
+    try:
+        entries = _entries(50)
+        first, cursor = mc.count_skills(entries, max_workers=2, previous={}, offset=0)
+        assert cursor == 0, cursor
+        assert sum(1 for r in first.values() if r["status"] == "ok") == 10
+        assert sum(1 for r in first.values() if r["status"] == "pending") == 40
+
+        second, _ = mc.count_skills(entries, max_workers=2, previous=first, offset=cursor)
+        counted = [k for k, r in first.items() if r["status"] == "ok"]
+        for key in counted:
+            assert second[key]["count"] == 1, second[key]
+            assert second[key]["status"] == "ok", second[key]
+
+        # Carrying the same row again must not stack another clause onto the note.
+        third, _ = mc.count_skills(entries, max_workers=2, previous=second, offset=0)
+        for key in counted:
+            note = third[key]["note"]
+            assert note.count(mc.CARRY_NOTE) <= 1, note
+    finally:
+        mc._jget = real
+
+
+def test_uncounted_repositories_go_first():
+    real, mc._jget = mc._jget, _fake_github(5)[0]
+    try:
+        entries = _entries(20)
+        previous = {f"acme/repo{i:04d}": {"full": f"acme/repo{i:04d}", "count": 3, "status": "ok",
+                                          "branch": "main", "path": "skills", "note": ""}
+                    for i in range(15)}
+        counts, _ = mc.count_skills(entries, max_workers=1, previous=previous, offset=0)
+        # The five that nobody had counted are exactly the five that got the quota.
+        for i in range(15, 20):
+            assert counts[f"acme/repo{i:04d}"]["status"] == "ok", counts[f"acme/repo{i:04d}"]
+    finally:
+        mc._jget = real
+
+
+def test_readme_round_trip_keeps_counts_and_cursor():
+    entries = _entries(3)
+    counts = {
+        "acme/repo0000": {"full": "acme/repo0000", "count": 12, "status": "ok", "branch": "main", "path": "skills", "note": ""},
+        "acme/repo0001": {"full": "acme/repo0001", "count": 0, "status": "missing", "branch": "main", "path": "skills", "note": "HTTP 404"},
+        "acme/repo0002": {"full": "acme/repo0002", "count": 7, "status": "truncated", "branch": "main", "path": "skills", "note": "tree truncated; count is lower bound"},
+    }
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "README.md"
+        path.write_text(mc.render_readme(entries, counts, next_offset=4242), encoding="utf-8")
+        previous, offset = mc.read_previous(str(path))
+        assert offset == 4242, offset
+        for key, row in counts.items():
+            assert previous[key]["count"] == row["count"], (key, previous[key])
+            assert previous[key]["status"] == row["status"], (key, previous[key])
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_"):
+            try:
+                fn()
+                print(f"ok   {name}")
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAIL {name}: {exc}")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## What is wrong

The scan makes one `git/trees` request per source repository. `skill_repos.json` holds **5174** of them, which is more than an hour's allowance, so every run spends the quota partway down the list and everything after that comes back `403`. `_count_skill` writes that straight into the table as `0 | ⛔ forbidden | HTTP 403`, which reads as "this repository is broken" for repositories that are public and fine.

The damage is not random, and that is the part that matters:

| README commit | unreachable rows |
|---|---|
| `59eb0e1` 12 Sep 11:22 | 392 |
| `b398f7b` 12 Sep 06:38 | 370 |
| `fcba2e6` 12 Sep 01:50 | 355 |
| `c4413bf` 11 Sep 23:41 | 354 |

**353 of those repositories are the same in all four runs**, and in the latest README every single one of the 392 sits at index **4780 or beyond** out of 5174. Indices 0–4779 are clean. That is the quota running out at a fixed point in a fixed order.

Source configs grow by appending, so a newly added repository always lands in the starved tail. It shows `0 skills, forbidden` from the day it is added and stays there. Checked against the API directly: `https://api.github.com/repos/<owner>/<name>/git/trees/main?recursive=1` answers `200` anonymously for the repositories the table calls forbidden.

## What this changes

Three changes, all inside the scan.

- **`Budget`** recognises the 403 that carries `X-RateLimit-Remaining: 0` (or `Retry-After`) and stops the run from issuing further requests. Today a run burns hundreds of calls that can only fail.
- **A repository the run could not reach keeps the number the previous run measured**, read back from the README that run wrote. A stale measured count is worth more than a fresh zero that was never measured. A repository nobody has counted yet gets a new `⏳ pending` status rather than `⛔ forbidden`, because a spent quota says nothing about the repository.
- **Uncounted repositories get the quota first**, and the rest rotate through a cursor kept in the README as an HTML comment (`<!-- scan-offset: N -->`). Over a few runs everything gets measured instead of the same head of the list being measured again and again. The cursor stays `0` while one run still covers the whole catalog, so nothing changes for smaller lists.

No workflow change, no new state file, no new dependency.

## How it was checked

`scripts/test_metadata_catalog.py` runs offline with plain `python3`, no pytest:

```
ok   test_readme_round_trip_keeps_counts_and_cursor
ok   test_spent_quota_never_erases_a_measured_count
ok   test_uncounted_repositories_go_first
```

Then the real pipeline against the live source list **with no token at all**, which is the harshest case at 60 requests per hour:

```
репозиториев из источника: 5174
Counter({'ok': 4609, 'pending': 366, 'missing': 197, 'truncated': 2})
живых строк, испорченных прогоном без токена: 0
```

Zero previously measured rows damaged, and it finished in five seconds instead of hammering the API. The current code in that same situation publishes about 5100 rows of `⛔ forbidden`.

## One note on CLAUDE.md

`CLAUDE.md` asks for `python -m scripts.skill_scraper generate-readme` before committing. I ran the same pipeline (`fetch_repos_from_sources` → `count_skills` → `render_readme`) and it produced no warnings or errors, but I deliberately did **not** commit a regenerated `README.md`: an unauthenticated local run cannot produce authoritative counts, and committing one would replace measured rows with pending ones. The workflow regenerates it with a token on the next schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)